### PR TITLE
chore: add PHPStan, commit config, and remove it from .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,5 @@ _ide_helper_models.php
 
 # Misc
 phpunit.xml
-phpstan.neon
 testbench.yaml
 /coverage

--- a/composer.json
+++ b/composer.json
@@ -28,6 +28,7 @@
         "pestphp/pest": "^3.0",
         "pestphp/pest-plugin-arch": "^3.0",
         "pestphp/pest-plugin-laravel": "^3.0",
+        "phpstan/phpstan": "^2.1",
         "spatie/laravel-ray": "^1.35"
     },
     "autoload": {

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,4 @@
+parameters:
+    level: max
+    paths:
+        - src


### PR DESCRIPTION
Installed phpstan/phpstan as a dev dependency to fix the error when running the 'analyse' script
Added phpstan.neon configuration file with level max and paths to src/ for consistent static analysis
Removed phpstan.neon from .gitignore to version control the static analysis config, ensuring all contributors and CI use the same rules