### PR TITLE
fix: return OTP as strict string with secure randomness

### DIFF
--- a/src/Support/PasswordGenerators/NumericOneTimePasswordGenerator.php
+++ b/src/Support/PasswordGenerators/NumericOneTimePasswordGenerator.php
@@ -13,11 +13,11 @@ class NumericOneTimePasswordGenerator implements OneTimePasswordGenerator
         return $this;
     }
 
-    public function generate(): string|int
+    public function generate(): string
     {
         $min = 10 ** ($this->numberOfDigits - 1);
         $max = (10 ** $this->numberOfDigits) - 1;
 
-        return rand($min, $max);
+        return (string) random_int($min, $max);
     }
 }

--- a/src/Support/PasswordGenerators/OneTimePasswordGenerator.php
+++ b/src/Support/PasswordGenerators/OneTimePasswordGenerator.php
@@ -4,5 +4,5 @@ namespace Spatie\LaravelOneTimePasswords\Support\PasswordGenerators;
 
 interface OneTimePasswordGenerator
 {
-    public function generate(): string|int;
+    public function generate(): string;
 }


### PR DESCRIPTION
- Enforced string return type in OneTimePasswordGenerator
- Used random_int() instead of rand() for better security
- Cast OTP to string to preserve leading zeros and improve compatibility

BREAKING CHANGE: OTP generators must now return string instead of int|string