### PR TITLE
docs: clarify return type in gatherProperties PHPDoc

### DIFF
--- a/src/Support/OriginInspector/DefaultOriginEnforcer.php
+++ b/src/Support/OriginInspector/DefaultOriginEnforcer.php
@@ -7,6 +7,9 @@ use Spatie\LaravelOneTimePasswords\Models\OneTimePassword;
 
 class DefaultOriginEnforcer implements OriginEnforcer
 {
+    /**
+     * @return array<string, (string|null)>
+     */
     public function gatherProperties(Request $request): array
     {
         return [


### PR DESCRIPTION
Updated PHPDoc to use array<string, (string|null)> for clearer union type notation
Explicitly indicates array values can be string or null
Improves static analysis and code readability