### PR TITLE
fix: validate action class config to ensure string type and avoid PHPStan errors

### DIFF
--- a/src/Exceptions/InvalidConfig.php
+++ b/src/Exceptions/InvalidConfig.php
@@ -15,4 +15,9 @@ class InvalidConfig extends Exception
     {
         return new self("The configured notification `{$notificationClass}` is not a valid notification class because it does not extend `Spatie\LaravelOneTimePasswords\Notifications\OneTimePasswordNotification`.");
     }
+
+    public static function invalidAction(string $actionName): self
+    {
+        return new self("The configured action for `{$actionName}` is missing or not a valid class string.");
+    }
 }

--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -51,6 +51,10 @@ class Config
     {
         $actionClass = config("one-time-passwords.actions.{$actionName}");
 
+        if (!is_string($actionClass) || trim($actionClass) === '') {
+            throw InvalidConfig::invalidAction($actionName);
+        }
+
         self::ensureValidActionClass($actionName, $actionBaseClass, $actionClass);
 
         return $actionClass;

--- a/tests/ConfigTest.php
+++ b/tests/ConfigTest.php
@@ -40,3 +40,13 @@ it('will fail when a wrong action is configured', function () {
 
     Config::getAction('create_one_time_password', CreateOneTimePasswordAction::class);
 })->throws(InvalidActionClass::class);
+
+it('will fail when an action is not a valid class string', function ($invalidValue, $description) {
+    updateConfig('one-time-passwords.actions.create_one_time_password', $invalidValue);
+
+    Config::getAction('create_one_time_password', CreateOneTimePasswordAction::class);
+})->with([
+    [[],        'array'],
+    ['   ',     'empty string'],
+    [null,      'null'],
+])->throws(InvalidConfig::class, 'The configured action for `create_one_time_password` is missing or not a valid class string.');


### PR DESCRIPTION
Added explicit check for string type and non-empty value in `getActionClass`
Added new `InvalidConfig::invalidAction` exception for invalid or missing action class config
Extended test suite to cover invalid action class config (null, empty string, array)
Fixes PHPStan errors related to return and argument types
