### PR TITLE
fix: validate config notification class to ensure string before type checks

### DIFF
--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -16,8 +16,8 @@ class Config
     {
         $modelClass = config('one-time-passwords.model');
 
-        if (! is_a($modelClass, OneTimePassword::class, true)) {
-            throw InvalidConfig::invalidModel($modelClass);
+        if (! is_string($modelClass) || ! is_a($modelClass, OneTimePassword::class, true)) {
+            throw InvalidConfig::invalidModel(is_scalar($modelClass) ? (string) $modelClass : gettype($modelClass));
         }
 
         return $modelClass;


### PR DESCRIPTION
Prevents calling is_a() with non-string values by verifying type before usage.
Also ensures return type is always a class-string as expected by static analysis tools.
