### PR TITLE
fix : strictly enforce string type for notification class config

### DIFF
--- a/src/Support/Config.php
+++ b/src/Support/Config.php
@@ -27,8 +27,8 @@ class Config
     {
         $notificationClass = config('one-time-passwords.notification');
 
-        if (! is_a($notificationClass, OneTimePasswordNotification::class, true)) {
-            throw InvalidConfig::invalidNotification($notificationClass);
+        if (! is_string($notificationClass) || ! is_a($notificationClass, OneTimePasswordNotification::class, true)) {
+            throw InvalidConfig::invalidNotification(is_scalar($notificationClass) ? (string) $notificationClass : gettype($notificationClass));
         }
 
         return $notificationClass;


### PR DESCRIPTION
Updated  to validate that the configured notification is a string and a valid subclass of OneTimePasswordNotification.
Added type check to prevent passing objects or invalid types, improving type safety and ensuring consistent return of a class-string.
Throws a clear exception if the config value is not a valid string class name.