### PR TITLE
fix(rules): enforce Eloquent Model type for OTP user

### DIFF
--- a/src/Rules/OneTimePasswordRule.php
+++ b/src/Rules/OneTimePasswordRule.php
@@ -5,11 +5,12 @@ namespace Spatie\LaravelOneTimePasswords\Rules;
 use Closure;
 use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Validation\ValidationRule;
+use Illuminate\Database\Eloquent\Model;
 use Spatie\LaravelOneTimePasswords\Actions\ConsumeOneTimePasswordAction;
 
 class OneTimePasswordRule implements ValidationRule
 {
-    public function __construct(protected Authenticatable $user) {}
+    public function __construct(protected Authenticatable & Model $user) {}
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {


### PR DESCRIPTION
Change constructor type hint from Authenticatable to Authenticatable&Model intersection type
Matches ConsumeOneTimePasswordAction's execute() method requirement
Ensures type safety when action interacts with Eloquent features
Prevents runtime errors from non-Model Authenticatable implementations

BREAKING CHANGE: Now strictly requires user to be both Authenticatable and Eloquent Model.