### PR TITLE
fix(validation): enforce string type for OTP input

### DIFF
--- a/src/Rules/OneTimePasswordRule.php
+++ b/src/Rules/OneTimePasswordRule.php
@@ -13,6 +13,10 @@ class OneTimePasswordRule implements ValidationRule
 
     public function validate(string $attribute, mixed $value, Closure $fail): void
     {
+        if (!is_string($value)) {
+            $fail('The one-time password must be a string.');
+            return;
+        }
         $result = app(ConsumeOneTimePasswordAction::class)->execute(
             $this->user,
             $value,

--- a/tests/OneTimePasswordsTest.php
+++ b/tests/OneTimePasswordsTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Spatie\LaravelOneTimePasswords\Enums\ConsumeOneTimePasswordResult;
+use Spatie\LaravelOneTimePasswords\Rules\OneTimePasswordRule;
 use Spatie\LaravelOneTimePasswords\Support\OriginInspector\DoNotEnforceOrigin;
 use Spatie\LaravelOneTimePasswords\Tests\TestSupport\Models\User;
 
@@ -130,4 +131,12 @@ it('will not login the user when the password is incorrect', function () {
     $result = $this->user->attemptLoginUsingOneTimePassword('wrong-password');
     expect($result)->toBe(ConsumeOneTimePasswordResult::IncorrectOneTimePassword);
     expect(auth()->check())->toBeFalse();
+});
+
+it('rejects non-string OTP codes', function () {
+    $rule = new OneTimePasswordRule($this->user);
+    
+    $rule->validate('otp', 12345, function ($message) {
+        expect($message)->toBe('The one-time password must be a string.');
+    });
 });


### PR DESCRIPTION
Add explicit string check to resolve PHPStan type errors
Return validation failure for non-string values
Add test case for non-string rejection

Test verification:
- New test confirms non-string values fail validation
- Existing tests ensure string handling remains unchanged