### PR TITLE
fix:[Config] Observe password length from config

### DIFF
--- a/src/Models/OneTimePassword.php
+++ b/src/Models/OneTimePassword.php
@@ -31,7 +31,7 @@ class OneTimePassword extends Model
     public static function generateFor(Model $model, int $expiresInMinutes = 10): self
     {
         return $model->oneTimePasswords()->create([
-            'password' => Str::random(6),
+            'password' => Str::random(config('one-time-passwords.password_length')),
             'expires_at' => Carbon::now()->addMinutes($expiresInMinutes),
         ]);
     }

--- a/src/Support/PasswordGenerators/NumericOneTimePasswordGenerator.php
+++ b/src/Support/PasswordGenerators/NumericOneTimePasswordGenerator.php
@@ -6,6 +6,10 @@ class NumericOneTimePasswordGenerator implements OneTimePasswordGenerator
 {
     protected int $numberOfDigits = 6;
 
+    public function __construct(){
+        $this->numberOfDigits(config('one-time-passwords.password_length'));
+    }
+
     public function numberOfDigits(int $numberOfDigits): self
     {
         $this->numberOfDigits = $numberOfDigits;

--- a/tests/OneTimePasswordsTest.php
+++ b/tests/OneTimePasswordsTest.php
@@ -25,6 +25,17 @@ it('can create a one-time password', function () {
     expect($oneTimePassword->expires_at->toDateTimeString())->toBe($expectedExpiresAt);
 });
 
+it('can create passwords with non-default length', function () {
+    updateConfig('one-time-passwords.password_length', '8');
+    $this->user->createOneTimePassword();
+
+    expect($this->user->oneTimePasswords)->toHaveCount(1);
+
+    $oneTimePassword = $this->user->oneTimePasswords->first();
+
+    expect($oneTimePassword->password)->toHaveLength(config('one-time-passwords.password_length'));
+});
+
 it('can consume a one-time password', function () {
     $oneTimePassword = $this->user->createOneTimePassword();
 


### PR DESCRIPTION
Make password length configurable.

Use config value for password length instead of hardcoded 6
Update generator to use config value
Add test to confirm custom length is respected

Test verification:
-    New test checks password has correct length from config
-    Existing tests remain unchanged and pass