### PR TITLE
Rename validation string `request_did_not_match` to `different_origin`

### DIFF
--- a/resources/lang/ar/validation.php
+++ b/resources/lang/ar/validation.php
@@ -3,6 +3,6 @@
 return [
     'no_one_time_passwords_found' => 'الرمز المدخل غير صحيح',
     'incorrect_one_time_password' => 'الرمز المدخل غير صحيح',
-    'request_did_not_match' => 'الرمز المدخل غير صحيح',
+    'different_origin' => 'الرمز المدخل غير صحيح',
     'one_time_password_expired' => 'الرمز المدخل لم يعد صالحا',
 ];

--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -3,6 +3,6 @@
 return [
     'no_one_time_passwords_found' => 'The given code is not correct',
     'incorrect_one_time_password' => 'The given code is not correct',
-    'request_did_not_match' => 'The given code is not correct',
+    'different_origin' => 'The given code is not correct',
     'one_time_password_expired' => 'The given code is not valid anymore',
 ];

--- a/resources/lang/fr/validation.php
+++ b/resources/lang/fr/validation.php
@@ -3,6 +3,6 @@
 return [
     'no_one_time_passwords_found' => 'Le code donné n’est pas correct',
     'incorrect_one_time_password' => 'Le code donné n’est pas correct',
-    'request_did_not_match' => 'Le code donné n’est pas correct',
+    'different_origin' => 'Le code donné n’est pas correct',
     'one_time_password_expired' => 'Le code donné n’est plus valide',
 ];

--- a/resources/lang/nl/validation.php
+++ b/resources/lang/nl/validation.php
@@ -3,6 +3,6 @@
 return [
     'no_one_time_passwords_found' => 'De ingevoerde code is niet correct',
     'incorrect_one_time_password' => 'De ingevoerde code is niet correct',
-    'request_did_not_match' => 'De ingevoerde code is niet correct',
+    'different_origin' => 'De ingevoerde code is niet correct',
     'one_time_password_expired' => 'De gegeven code is niet meer geldig',
 ];

--- a/resources/lang/pt_BR/validation.php
+++ b/resources/lang/pt_BR/validation.php
@@ -3,6 +3,6 @@
 return [
     'no_one_time_passwords_found' => 'O código informado está incorreto.',
     'incorrect_one_time_password' => 'O código informado está incorreto.',
-    'request_did_not_match' => 'O código informado está incorreto.',
+    'different_origin' => 'O código informado está incorreto.',
     'one_time_password_expired' => 'O código informado expirou.',
 ];

--- a/resources/lang/pt_PT/validation.php
+++ b/resources/lang/pt_PT/validation.php
@@ -3,6 +3,6 @@
 return [
     'no_one_time_passwords_found' => 'O código fornecido não está correto',
     'incorrect_one_time_password' => 'O código fornecido não está correto',
-    'request_did_not_match' => 'O código fornecido não está correto',
+    'different_origin' => 'O código fornecido não está correto',
     'one_time_password_expired' => 'O código fornecido já não é válido',
 ];

--- a/resources/lang/ru/validation.php
+++ b/resources/lang/ru/validation.php
@@ -3,6 +3,6 @@
 return [
     'no_one_time_passwords_found' => 'Указанный код неверен',
     'incorrect_one_time_password' => 'Указанный код неверен',
-    'request_did_not_match' => 'Указанный код неверен',
+    'different_origin' => 'Указанный код неверен',
     'one_time_password_expired' => 'Срок действия кода истек',
 ];


### PR DESCRIPTION
In https://github.com/spatie/laravel-one-time-passwords/commit/b2d7d28718da960d2f2d92a59d21d8107c4e0c6d#diff-1717cd54ac851ec56d0b383a4252684c767d029f072f073122a7cb4197802e16, `ValidateOneTimePasswordResult::RequestDidNotMatch` was renamed to `ValidateOneTimePasswordResult::DifferentOrigin`, but the validation messages were not changed. Here I'm aligning them with the current enum values.