### PR TITLE
Add English translation for `rate_limit_exceeded`

### DIFF
--- a/resources/lang/en/validation.php
+++ b/resources/lang/en/validation.php
@@ -5,4 +5,5 @@ return [
     'incorrect_one_time_password' => 'The given code is not correct',
     'different_origin' => 'The given code is not correct',
     'one_time_password_expired' => 'The given code is not valid anymore',
+    'rate_limit_exceeded' => 'Too many requests',
 ];


### PR DESCRIPTION
The `rate_limit_exceeded` message did not have a translation in any language - resulting in the visualization of a raw `one-time-passwords::validation.rate_limit_exceeded` in case that error occurs.

I have added the English translation. All other languages are still missing it, as I'm not able to provide it.