### PR TITLE
Support Laravel 13

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -18,7 +18,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, windows-latest]
         php: [8.5, 8.4]
-        laravel: [12.*]
+        laravel: [12.*, 13.*]
         stability: [prefer-stable]
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "require": {
         "php": "^8.4",
         "spatie/laravel-package-tools": "^1.92.7",
-        "illuminate/contracts": "^12.0"
+        "illuminate/contracts": "^12.0|^13.0"
     },
     "suggest": {
         "livewire/flux": "For an enhanced OTP input UI component"
@@ -27,7 +27,7 @@
         "laravel/pint": "^1.25.1",
         "livewire/livewire": "^3.7|^4.0",
         "nunomaduro/collision": "^8.8.3",
-        "orchestra/testbench": "^10.0.0",
+        "orchestra/testbench": "^10.0.0|^11.0",
         "pestphp/pest": "^3.0|^4.1.5",
         "pestphp/pest-plugin-laravel": "^3.0|^4.0",
         "phpstan/phpstan": "^2.1.32",


### PR DESCRIPTION
## Summary

- Widen `illuminate/contracts` constraint to `^12.0|^13.0`
- Widen `orchestra/testbench` constraint to `^10.0.0|^11.0`
- Add Laravel 13 (`13.*`) to the CI test matrix