### PR TITLE
Fix #55: respect enforce_same_origin config value

### DIFF
--- a/config/one-time-passwords.php
+++ b/config/one-time-passwords.php
@@ -1,5 +1,12 @@
 <?php
 
+use Spatie\OneTimePasswords\Actions\ConsumeOneTimePasswordAction;
+use Spatie\OneTimePasswords\Actions\CreateOneTimePasswordAction;
+use Spatie\OneTimePasswords\Models\OneTimePassword;
+use Spatie\OneTimePasswords\Notifications\OneTimePasswordNotification;
+use Spatie\OneTimePasswords\Support\OriginInspector\DefaultOriginEnforcer;
+use Spatie\OneTimePasswords\Support\PasswordGenerators\NumericOneTimePasswordGenerator;
+
 return [
     /*
      * one-time passwords should be consumed within this number of minutes
@@ -25,12 +32,12 @@ return [
      * If you do not wish to enforce this, set this value to
      * Spatie\OneTimePasswords\Support\OriginInspector\DoNotEnforceOrigin
      */
-    'origin_enforcer' => Spatie\OneTimePasswords\Support\OriginInspector\DefaultOriginEnforcer::class,
+    'origin_enforcer' => DefaultOriginEnforcer::class,
 
     /*
      * This class generates a random password
      */
-    'password_generator' => Spatie\OneTimePasswords\Support\PasswordGenerators\NumericOneTimePasswordGenerator::class,
+    'password_generator' => NumericOneTimePasswordGenerator::class,
 
     /*
      * By default, the password generator will create a password with
@@ -56,12 +63,12 @@ return [
     /*
      * The model uses to store one-time passwords
      */
-    'model' => Spatie\OneTimePasswords\Models\OneTimePassword::class,
+    'model' => OneTimePassword::class,
 
     /*
      * The notification used to send a one-time password to a user
      */
-    'notification' => Spatie\OneTimePasswords\Notifications\OneTimePasswordNotification::class,
+    'notification' => OneTimePasswordNotification::class,
 
     /*
      * These class are responsible for performing core tasks regarding one-time passwords.
@@ -69,7 +76,7 @@ return [
      * by specifying your custom class name here.
      */
     'actions' => [
-        'create_one_time_password' => Spatie\OneTimePasswords\Actions\CreateOneTimePasswordAction::class,
-        'consume_one_time_password' => Spatie\OneTimePasswords\Actions\ConsumeOneTimePasswordAction::class,
+        'create_one_time_password' => CreateOneTimePasswordAction::class,
+        'consume_one_time_password' => ConsumeOneTimePasswordAction::class,
     ],
 ];

--- a/src/OneTimePasswordsServiceProvider.php
+++ b/src/OneTimePasswordsServiceProvider.php
@@ -7,6 +7,7 @@ use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\OneTimePasswords\Livewire\OneTimePasswordComponent;
 use Spatie\OneTimePasswords\Support\Config;
+use Spatie\OneTimePasswords\Support\OriginInspector\DoNotEnforceOrigin;
 use Spatie\OneTimePasswords\Support\OriginInspector\OriginEnforcer;
 use Spatie\OneTimePasswords\Support\PasswordGenerators\OneTimePasswordGenerator;
 
@@ -24,7 +25,11 @@ class OneTimePasswordsServiceProvider extends PackageServiceProvider
 
     public function packageRegistered(): void
     {
-        $this->app->bind(OriginEnforcer::class, config('one-time-passwords.origin_enforcer'));
+        $originEnforcer = config('one-time-passwords.enforce_same_origin', true)
+            ? config('one-time-passwords.origin_enforcer')
+            : DoNotEnforceOrigin::class;
+
+        $this->app->bind(OriginEnforcer::class, $originEnforcer);
 
         $this->app->bind(OneTimePasswordGenerator::class, function () {
             $generator = Config::getPasswordGenerator();

--- a/tests/OneTimePasswordsTest.php
+++ b/tests/OneTimePasswordsTest.php
@@ -126,6 +126,19 @@ it('has an inspector that does not enforce origin', function () {
     expect($result)->toBe(ConsumeOneTimePasswordResult::Ok);
 });
 
+it('will not enforce origin when enforce_same_origin config is false', function () {
+    updateConfig('one-time-passwords.enforce_same_origin', false);
+
+    $oneTimePassword = $this->user->createOneTimePassword();
+
+    $oneTimePassword->update([
+        'origin_properties' => array_merge($oneTimePassword->origin_properties, ['userAgent' => 'some-other-user-agent']),
+    ]);
+
+    $result = $this->user->consumeOneTimePassword($oneTimePassword->password);
+    expect($result)->toBe(ConsumeOneTimePasswordResult::Ok);
+});
+
 it('can log in the user', function () {
     $oneTimePassword = $this->user->createOneTimePassword();
 


### PR DESCRIPTION
Fixes #55

## Changes

The `enforce_same_origin` config option was defined in the config file but never actually read anywhere. The service provider now checks this value: when set to `false`, it binds `DoNotEnforceOrigin` regardless of the `origin_enforcer` config, making the boolean switch work as documented.

- Updated `OneTimePasswordsServiceProvider` to read `enforce_same_origin` and bind `DoNotEnforceOrigin` when `false`
- Added test verifying the config toggle works