### PR TITLE
Remove redundant session regeneration line from README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,10 +54,7 @@ use Spatie\OneTimePasswords\Enums\ConsumeOneTimePasswordResult;
 $result = $user->attemptLoginUsingOneTimePassword($oneTimePassword);
 
 if ($result->isOk()) {
-     // it is best practice to regenerate the session id after a login   
-     $request->session()->regenerate();
-              
-     return redirect()->intended('dashboard');
+    return redirect()->intended('dashboard');
 }
 
 return back()->withErrors([


### PR DESCRIPTION
## Summary

The login example in the README tells users to call `$request->session()->regenerate()` after a successful `attemptLoginUsingOneTimePassword()`, framed as a security best practice. This is redundant.

`attemptLoginUsingOneTimePassword()` calls `auth()->login($this, $remember)` internally. Laravel's `Illuminate\Auth\SessionGuard::login()` invokes `updateSession()`, which calls `$this->session->regenerate(true)` (vendor/laravel/framework/src/Illuminate/Auth/SessionGuard.php, around line 588). The session id is already regenerated and the previous session data is destroyed as part of the login itself.

Following the README as written results in calling `regenerate()` twice. It is harmless but misleading, and it suggests to readers that the package leaves a session-fixation gap that they need to close manually.

## Change

Drop the comment and the `$request->session()->regenerate();` line from the example block. No code or behavior changes.