### PR TITLE
Return early from Timebox on successful OTP consumption

### DIFF
--- a/src/Actions/ConsumeOneTimePasswordAction.php
+++ b/src/Actions/ConsumeOneTimePasswordAction.php
@@ -30,7 +30,7 @@ class ConsumeOneTimePasswordAction
         Request $request
     ): ConsumeOneTimePasswordResult {
         return (new Timebox)->call(
-            callback: fn () => $this->consumeOneTimePassword($user, $password, $request),
+            callback: fn (Timebox $timebox) => $this->consumeOneTimePassword($user, $password, $request, $timebox),
             microseconds: CarbonInterval::milliseconds(100)->microseconds,
         );
     }
@@ -41,7 +41,8 @@ class ConsumeOneTimePasswordAction
     protected function consumeOneTimePassword(
         Authenticatable $user,
         string $password,
-        Request $request
+        Request $request,
+        Timebox $timebox,
     ): ConsumeOneTimePasswordResult {
         $oneTimePasswords = $this->getAllOneTimePasswordsForUser($user);
 
@@ -73,6 +74,8 @@ class ConsumeOneTimePasswordAction
         }
 
         $this->onSuccessfullyValidated($user, $oneTimePassword);
+
+        $timebox->returnEarly();
 
         return ConsumeOneTimePasswordResult::Ok;
     }

--- a/tests/OneTimePasswordsTest.php
+++ b/tests/OneTimePasswordsTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Illuminate\Support\Sleep;
 use Spatie\OneTimePasswords\Enums\ConsumeOneTimePasswordResult;
 use Spatie\OneTimePasswords\Support\OriginInspector\DoNotEnforceOrigin;
 use Spatie\OneTimePasswords\Tests\TestSupport\Models\User;
@@ -155,4 +156,28 @@ it('will not login the user when the password is incorrect', function () {
     $result = $this->user->attemptLoginUsingOneTimePassword('wrong-password');
     expect($result)->toBe(ConsumeOneTimePasswordResult::IncorrectOneTimePassword);
     expect(auth()->check())->toBeFalse();
+});
+
+it('does not pad execution time via Timebox when the one-time password is valid', function () {
+    Sleep::fake();
+
+    $oneTimePassword = $this->user->createOneTimePassword();
+
+    $result = $this->user->consumeOneTimePassword($oneTimePassword->password);
+
+    expect($result)->toBe(ConsumeOneTimePasswordResult::Ok);
+
+    Sleep::assertNeverSlept();
+});
+
+it('pads execution time via Timebox when the one-time password is invalid', function () {
+    Sleep::fake();
+
+    $this->user->createOneTimePassword();
+
+    $result = $this->user->consumeOneTimePassword('wrong-password');
+
+    expect($result)->toBe(ConsumeOneTimePasswordResult::IncorrectOneTimePassword);
+
+    Sleep::assertSleptTimes(1);
 });


### PR DESCRIPTION
`ConsumeOneTimePasswordAction` uses `Timebox` to enforce a minimum response time, which also applies when the code is correct. To match [Laravel convention](https://github.com/laravel/framework/blob/f9b0bfc72722d2fa7c5a3eb0519c66e1db6d84f0/src/Illuminate/Auth/SessionGuard.php#L319), it should return early on success.

**My suggestion is to remove `Timebox` entirely**. It was designed to obscure whether an email/username exists or a password is wrong — but this package already expects a resolved User instance. That lookup happens before this action, likely without any timing protection, so Timebox here offers no real security benefit: any timing difference an attacker could observe would already be attributable to the OTP check alone.

**Alternatively**, if the package were to take ownership of user resolution — accepting an email or identifier instead of a User instance — then Timebox would be the right tool here. It could wrap both the user lookup and the OTP check in a single timed envelope, preventing an attacker from inferring whether a given identifier belongs to a registered user or whether the code was simply wrong. That said, this would likely constitute a breaking change requiring a major version bump, and would need further discussion on how it should be designed and integrated.

@freekmurze if you agree with the `Timebox` removal, I'm happy to create a new PR otherwise happy to brainstorm for the addition of the User lookup.